### PR TITLE
Add appropriate MacOS Network entitlements

### DIFF
--- a/vase-client/macos/Runner/DebugProfile.entitlements
+++ b/vase-client/macos/Runner/DebugProfile.entitlements
@@ -8,5 +8,7 @@
 	<true/>
 	<key>com.apple.security.network.server</key>
 	<true/>
+	<key>com.apple.security.network.client</key>
+<true/>
 </dict>
 </plist>

--- a/vase-client/macos/Runner/DebugProfile.entitlements
+++ b/vase-client/macos/Runner/DebugProfile.entitlements
@@ -9,6 +9,6 @@
 	<key>com.apple.security.network.server</key>
 	<true/>
 	<key>com.apple.security.network.client</key>
-<true/>
+	<true/>
 </dict>
 </plist>

--- a/vase-client/macos/Runner/Release.entitlements
+++ b/vase-client/macos/Runner/Release.entitlements
@@ -4,5 +4,7 @@
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
Allow for running the release and debug versions of Vase on the MacOS desktop.